### PR TITLE
Add proxy support

### DIFF
--- a/MOREHELP.md
+++ b/MOREHELP.md
@@ -45,6 +45,7 @@ run_at_finish =
 use_locks = True
 clear_temp_files = False
 do_heartbeat = True
+proxy = 
 ```
 
 ```username```  **—**  Instagram username to login with.
@@ -74,3 +75,7 @@ do_heartbeat = True
 ```clear_temp_files```  **—**  When set to True, PyInstaLive will delete all temporary files that were downloaded as well as the folders which contained these files. Replay folders created by PyInstaLive will not be deleted because they are used to determine if a replay has already been downloaded.
 
 ```do_heartbeat```  **—**  When set to True, PyInstaLive will check the livestream's active status. If set to False no checks will be conducted, and the logged in user will not show up as a viewer during the livestream. May cause degraded performance.
+
+```proxy```  **—**  When set, PyInstaLive will use the specified HTTP proxy. The format should be similar to http://user:pass@proxy.com:12345
+
+

--- a/pyinstalive/auth.py
+++ b/pyinstalive/auth.py
@@ -45,7 +45,7 @@ def onlogin_callback(api, cookie_file):
         logger.separator()
 
 
-def authenticate(username, password, force_use_login_args=False, proxy=None):
+def authenticate(username, password, force_use_login_args=False):
     ig_api = None
     try:
         if force_use_login_args:
@@ -60,7 +60,7 @@ def authenticate(username, password, force_use_login_args=False, proxy=None):
             # login new
             ig_api = Client(
                 username, password,
-                on_login=lambda x: onlogin_callback(x, cookie_file), proxy=proxy)
+                on_login=lambda x: onlogin_callback(x, cookie_file), proxy=pil.proxy)
         else:
             with open(cookie_file) as file_data:
                 cached_settings = json.load(file_data, object_hook=from_json)
@@ -71,7 +71,7 @@ def authenticate(username, password, force_use_login_args=False, proxy=None):
             try:
                 ig_api = Client(
                     username, password,
-                    settings=cached_settings, proxy=proxy)
+                    settings=cached_settings, proxy=pil.proxy)
 
             except ClientCookieExpiredError as e:
                 logger.warn('The current cookie file has expired, creating a new one.')
@@ -79,7 +79,7 @@ def authenticate(username, password, force_use_login_args=False, proxy=None):
                 ig_api = Client(
                     username, password,
                     device_id=device_id,
-                    on_login=lambda x: onlogin_callback(x, cookie_file), proxy=proxy)
+                    on_login=lambda x: onlogin_callback(x, cookie_file), proxy=pil.proxy)
 
     except (ClientLoginError, ClientError) as e:
         logger.separator()

--- a/pyinstalive/auth.py
+++ b/pyinstalive/auth.py
@@ -45,7 +45,7 @@ def onlogin_callback(api, cookie_file):
         logger.separator()
 
 
-def authenticate(username, password, force_use_login_args=False):
+def authenticate(username, password, force_use_login_args=False, proxy=None):
     ig_api = None
     try:
         if force_use_login_args:
@@ -60,7 +60,7 @@ def authenticate(username, password, force_use_login_args=False):
             # login new
             ig_api = Client(
                 username, password,
-                on_login=lambda x: onlogin_callback(x, cookie_file))
+                on_login=lambda x: onlogin_callback(x, cookie_file), proxy=proxy)
         else:
             with open(cookie_file) as file_data:
                 cached_settings = json.load(file_data, object_hook=from_json)
@@ -71,7 +71,7 @@ def authenticate(username, password, force_use_login_args=False):
             try:
                 ig_api = Client(
                     username, password,
-                    settings=cached_settings)
+                    settings=cached_settings, proxy=proxy)
 
             except ClientCookieExpiredError as e:
                 logger.warn('The current cookie file has expired, creating a new one.')
@@ -79,7 +79,7 @@ def authenticate(username, password, force_use_login_args=False):
                 ig_api = Client(
                     username, password,
                     device_id=device_id,
-                    on_login=lambda x: onlogin_callback(x, cookie_file))
+                    on_login=lambda x: onlogin_callback(x, cookie_file), proxy=proxy)
 
     except (ClientLoginError, ClientError) as e:
         logger.separator()

--- a/pyinstalive/constants.py
+++ b/pyinstalive/constants.py
@@ -20,4 +20,5 @@ run_at_finish =
 use_locks = True
 clear_temp_files = False
 do_heartbeat = False
+proxy =
     """

--- a/pyinstalive/pil.py
+++ b/pyinstalive/pil.py
@@ -74,3 +74,4 @@ def initialize():
     clear_temp_files = False
     has_guest = None
     do_heartbeat = False
+    proxy = None

--- a/pyinstalive/pil.py
+++ b/pyinstalive/pil.py
@@ -43,6 +43,7 @@ def initialize():
     global clear_temp_files
     global has_guest
     global do_heartbeat
+    global proxy
     ig_api = None
     ig_user = ""
     ig_pass = ""

--- a/pyinstalive/startup.py
+++ b/pyinstalive/startup.py
@@ -82,6 +82,7 @@ def validate_inputs(config, args, unknown_args):
         pil.ffmpeg_path = config.get('pyinstalive', 'ffmpeg_path')
         pil.args = args
         pil.config = config
+        pil.proxy = config.get('pyinstalive', 'proxy')
 
         if args.configpath:
             pil.config_path = args.configpath
@@ -268,13 +269,13 @@ def run():
 
     if validate_inputs(config, args, unknown_args):
         if not args.username and not args.password:
-            pil.ig_api = auth.authenticate(username=pil.ig_user, password=pil.ig_pass)
+            pil.ig_api = auth.authenticate(username=pil.ig_user, password=pil.ig_pass, proxy=pil.proxy)
         elif (args.username and not args.password) or (args.password and not args.username):
             logger.warn("Missing --username or --password argument. Falling back to config file.")
             logger.separator()
-            pil.ig_api = auth.authenticate(username=pil.ig_user, password=pil.ig_pass)
+            pil.ig_api = auth.authenticate(username=pil.ig_user, password=pil.ig_pass, proxy=pil.proxy)
         elif args.username and args.password:
-            pil.ig_api = auth.authenticate(username=args.username, password=args.password, force_use_login_args=True)
+            pil.ig_api = auth.authenticate(username=args.username, password=args.password, force_use_login_args=True, proxy=pil.proxy)
 
         if pil.ig_api:
             if pil.dl_user or pil.args.downloadfollowing:

--- a/pyinstalive/startup.py
+++ b/pyinstalive/startup.py
@@ -4,6 +4,7 @@ import os
 import logging
 import platform
 import subprocess
+from urllib.parse import urlparse
 
 try:
     import pil
@@ -189,6 +190,12 @@ def validate_inputs(config, args, unknown_args):
                 logger.warn("Custom config path is invalid, falling back to default path: {:s}".format(pil.dl_path))
                 logger.separator()
 
+        if pil.proxy != None:
+            parsed_url = urlparse(pil.proxy)
+            if (not parsed_url.netloc or not parsed_url.scheme):
+                error_arr.append(['proxy', 'None'])
+                pil.proxy = None
+
         if error_arr:
             for error in error_arr:
                 logger.warn("Invalid value for '{:s}'. Using default value: {:s}".format(error[0], error[1]))
@@ -269,13 +276,13 @@ def run():
 
     if validate_inputs(config, args, unknown_args):
         if not args.username and not args.password:
-            pil.ig_api = auth.authenticate(username=pil.ig_user, password=pil.ig_pass, proxy=pil.proxy)
+            pil.ig_api = auth.authenticate(username=pil.ig_user, password=pil.ig_pass)
         elif (args.username and not args.password) or (args.password and not args.username):
             logger.warn("Missing --username or --password argument. Falling back to config file.")
             logger.separator()
-            pil.ig_api = auth.authenticate(username=pil.ig_user, password=pil.ig_pass, proxy=pil.proxy)
+            pil.ig_api = auth.authenticate(username=pil.ig_user, password=pil.ig_pass)
         elif args.username and args.password:
-            pil.ig_api = auth.authenticate(username=args.username, password=args.password, force_use_login_args=True, proxy=pil.proxy)
+            pil.ig_api = auth.authenticate(username=args.username, password=args.password, force_use_login_args=True)
 
         if pil.ig_api:
             if pil.dl_user or pil.args.downloadfollowing:

--- a/pyinstalive/startup.py
+++ b/pyinstalive/startup.py
@@ -82,7 +82,7 @@ def validate_inputs(config, args, unknown_args):
         pil.ffmpeg_path = config.get('pyinstalive', 'ffmpeg_path')
         pil.args = args
         pil.config = config
-        pil.proxy = config.get('pyinstalive', 'proxy')
+        pil.proxy = config.get('pyinstalive', 'proxy', fallback=None)
 
         if args.configpath:
             pil.config_path = args.configpath

--- a/pyinstalive/startup.py
+++ b/pyinstalive/startup.py
@@ -190,7 +190,7 @@ def validate_inputs(config, args, unknown_args):
                 logger.warn("Custom config path is invalid, falling back to default path: {:s}".format(pil.dl_path))
                 logger.separator()
 
-        if pil.proxy != None:
+        if pil.proxy != None and pil.proxy != '':
             parsed_url = urlparse(pil.proxy)
             if (not parsed_url.netloc or not parsed_url.scheme):
                 error_arr.append(['proxy', 'None'])


### PR DESCRIPTION
Adds support for using an HTTP proxy. Instagram_private_api supports it, and this PR exposes a configuration setting that is passed through to the constructor.